### PR TITLE
(PT-260) Add error handling to gather_facts plan

### DIFF
--- a/lib/puppet/functions/convert_to_fact_name.rb
+++ b/lib/puppet/functions/convert_to_fact_name.rb
@@ -34,5 +34,15 @@ Puppet::Functions.create_function(:'convert_to_fact_name') do
     #   character that is not a letter or underscore.
     # * Third, .downcase changes any capital letters to lowercase
     raw_string.strip.gsub(/\W/, '_').downcase
+  rescue Exception => e
+    # Capture _all_ exceptions from this operation and wrap them in
+    # a Bolt::Error type which is thrown. We wrap all errors in this
+    # type so that when plans use this function they can catch any
+    # failures with catch_errors() (that function only catches the
+    # Bolt::Error type).
+    raise Bolt::Error.new(
+      "failed to translate '#{raw_string}' to fact name: #{e.message}",
+      'fact-name-translation-failure'
+    )
   end
 end

--- a/lib/puppet/functions/sys_output_to_hash.rb
+++ b/lib/puppet/functions/sys_output_to_hash.rb
@@ -64,6 +64,16 @@ Puppet::Functions.create_function(:'sys_output_to_hash') do
     # Return the fully formed translated_output hash as the result
     # of this puppet function call
     translated_output
+  rescue Exception => e
+    # Capture _all_ exceptions from this operation and wrap them in
+    # a Bolt::Error type which is thrown. We wrap all errors in this
+    # type so that when plans use this function they can catch any
+    # failures with catch_errors() (that function only catches the
+    # Bolt::Error type).
+    raise Bolt::Error.new(
+      "Failed to translate raw output to facts: #{e.message}",
+      'output-translation-failure'
+    )
   end
 
   # Remove any machine prompt strings from the raw output, leaving

--- a/plans/gather_facts.pp
+++ b/plans/gather_facts.pp
@@ -17,6 +17,18 @@
 #   When set to true, the plan returns the hash of gathered facts and
 #   does not publish any facts.
 #
+# @return [Hash]
+#   A hash containing key/value data on any failures that occured processing
+#   individual targets. Top-level keys in the hash are target names, and their
+#   associated values are the failure that occured for that target.
+#
+#   If dry_run is set to true, the Hash also includes key/value data on what
+#   the plan would have submitted as facts for all targets that succeeded.
+#   The structure of successful key/value entries is similar: keys are target
+#   names, and values contain the data that would have been submitted
+#
+#   If dry_run is false and all targets succeed: an empty hash is returned
+#
 plan fortinet_facts::gather_facts (
   TargetSpec $targets,
   String     $static_facts_file = undef,
@@ -28,7 +40,7 @@ plan fortinet_facts::gather_facts (
 get sys performance status
 get sys status
 | COMMAND
-  $command_result = run_command($fortinet_command, $targets)
+  $command_result = run_command($fortinet_command, $targets, '_catch_errors' => true)
 
   if $static_facts_file {
     # Read and parse all statically defined facts from the static_facts.yaml
@@ -39,53 +51,133 @@ get sys status
   # readable as a set of facts.
   #
   # The following uses `map` to iterate over the target results and parse
-  # successful results in to structure readable as a set of facts. The `map`
-  # operation will return each processed result combined in an array.
+  # results in to structure readable as a set of facts. The `map` operation
+  # will return each processed result combined in an array.
+  #
+  # When processing each individual result, values returned back to the
+  # .map operation which are added to the $all_target_facts array are all
+  # of the same form: [ target_name, value ] (an array of size two with
+  # two values: the target name and the actual value). This means
+  # $all_target_facts will be in the form
+  #
+  # [ [ target_name, value], [ another_target_name, another_value] ]
+  #
+  # We create this structure specifically so that we can turn the
+  # $all_target_facts array in to a hash of the structure:
+  #
+  # { target_name => value, another_target_name => another_value }
+  #
+  # See: https://puppet.com/docs/puppet/7.5/typecasting.html#converting-data-structures
+  # for more detailed docs on why that structure of arrays
+  # produces the desired outcome of a Hash.
   $all_target_facts = $command_result.map |$target_result| {
     $target_name = String($target_result.target.name)
-    # Take the raw output from the commands run on the target and ensure
-    # they are formatted as a string.
-    $raw_output = String($target_result.value()['stdout'])
-    # Pull the static facts for this target form the static_facts hash
-    $target_static_facts = $static_facts[$target_name]['facts']
-    # Parse the output from the run_command operation in to a hash of
-    # key value pairs. These will become facts. The sys_output_to_hash
-    # function is defined in:
-    # fortinet_facts/lib/puppet/functions/sys_output_to_hash.rb
-    $target_facts = sys_output_to_hash($raw_output)
-    # Create a result hash formatted for use with the puppetdb_command
-    # action performed later. The format for this hash is defined by the
-    # API called to actually publish these facts.
-    #
-    # Values for 'environment', 'producer_timestamp', and 'producer' are
-    # all defaults that need to be provided for the API to work, but
-    # generally aren't useful in the context of Connect. All three values
-    # are set for us always and shouldn't be modified.
-    #
-    # Values for 'certname' and 'values' are the important pieces of data
-    # for this facts gathering operation:
-    #   * 'certname' is what identifies the target that will have facts
-    #      updated in the database.
-    #   * 'values' are the fact values that will be published in to the
-    #     database.
-    $result_hash = {
-      'certname' => $target_name,
-      'environment' => 'production',
-      'producer_timestamp' => "${Timestamp.new().strftime('%Y-%m-%dT%H:%M:%S%:z')}",
-      'producer' => 'connect',
-      # The actual facts set for each target will be a merged hash of
-      # both the static and dynamically generated facts
-      'values' => $target_static_facts + $target_facts
+    # Check if the result of the run_command operation for this target
+    # was successful. If it was not, it's processed differently below.
+    if $target_result.ok() {
+      # Take the raw output from the commands run on the target and ensure
+      # they are formatted as a string.
+      $raw_output = String($target_result.value()['stdout'])
+      # Pull the static facts for this target form the static_facts hash
+      $target_static_facts = $static_facts[$target_name]['facts']
+      # Parse the output from the run_command operation in to a hash of
+      # key value pairs. These will become facts. The sys_output_to_hash
+      # function is defined in:
+      # fortinet_facts/lib/puppet/functions/sys_output_to_hash.rb
+      $target_facts = catch_errors() || {
+        sys_output_to_hash($raw_output)
+      }
+      if $target_facts =~ Error {
+        # If the sys_output_to_hash translation fails (in this case when
+        # the type for the target_facts var is Error): we don't fail the
+        # entire plan but instead return the error to the map operation
+        # to be included in the $all_target_facts array.
+        #
+        # Logic below will check for any Error results in the $all_target_facts
+        # array and process the error differently from successful results
+        [ $target_name, $target_facts ]
+      } else {
+        # Create a result hash formatted for use with the puppetdb_command
+        # action performed later. The format for this hash is defined by the
+        # API called to actually publish these facts.
+        #
+        # Values for 'environment', 'producer_timestamp', and 'producer' are
+        # all defaults that need to be provided for the API to work, but
+        # generally aren't useful in the context of Connect. All three values
+        # are set for us always and shouldn't be modified.
+        #
+        # Values for 'certname' and 'values' are the important pieces of data
+        # for this facts gathering operation:
+        #   * 'certname' is what identifies the target that will have facts
+        #      updated in the database.
+        #   * 'values' are the fact values that will be published in to the
+        #     database.
+        $result_hash = {
+          'certname' => $target_name,
+          'environment' => 'production',
+          'producer_timestamp' => "${Timestamp.new().strftime('%Y-%m-%dT%H:%M:%S%:z')}",
+          'producer' => 'connect',
+          # The actual facts set for each target will be a merged hash of
+          # both the static and dynamically generated facts
+          'values' => $target_static_facts + $target_facts
+        }
+        # This $result_hash is sent back to the .map operation to be added to the
+        # $all_target_facts array
+        [ $target_name, $result_hash ]
+      }
+    } else {
+      # This is where we process target results from the original run_command operation
+      # that were not successful. Processing in this case is trivial: we just return the
+      # error result itself back to the .map operation to be added to the $all_target_facts
+      # array
+      #
+      # Logic below will check for any Error results in the $all_target_facts
+      # array and process the error differently from successful results
+      [ $target_name, $target_result.error() ]
     }
-    $result_hash
   }
+  # If dry_run is set to true: return the $all_target_facts array translated in to a hash
   if $dry_run {
-    return $all_target_facts
+    return Hash($all_target_facts)
   } else {
-    # Iterate over all target facts collected and publish them to the DB using
-    # puppetdb_command.
-    $all_target_facts.each |$target_fact_payload| {
-      puppetdb_command('replace_facts', 5, $target_fact_payload)
+    # Translate $all_target_facts to a hash (see comment about the first .map operation
+    # for details on what this hash will look like) and then iterate over that hash
+    # processing each result based on what type it is. Failures are returned to this
+    # .map operation along with the target name for which the failure occured.
+    #
+    # Only failure results are returned to this .map operation, including both entries
+    # in $all_target_facts that are already errors and any new errors that occur when
+    # attempting the puppetdb_command operation is performed. $final_result can then be
+    # translated to a hash that is either:
+    #   * An empty hash if every part of this plan succeeded
+    #   * A hash of key/value pairs where keys are target names and the values contain
+    #     details of what error occured when processing that target
+    $final_result = Hash($all_target_facts).map |$payload_target_name, $target_fact_payload| {
+      if $target_fact_payload =~ Error {
+        [ $payload_target_name, $target_fact_payload ]
+      } else {
+        # Catch any errors from attempting the puppetdb_command operation and return
+        # them to the .map operation. If the operation succeeds, don't return anything
+        # to the map operation (by default a value of 'undef' will get added if nothing
+        # is returned directly to .map, these undef values are filtered out of the final
+        # output below)
+        $pdb_command_result = catch_errors() || {
+          puppetdb_command('replace_facts', 5, $target_fact_payload)
+        }
+        if $pdb_command_result =~ Error {
+          [ $payload_target_name, $pdb_command_result ]
+        }
+      }
     }
+    # Filter out any array items that are undef (undef values are added to the
+    # final_result array for targets that fully succeeded) and then translate
+    # the result of that filtering in to a hash. The resulting hash should now
+    # only contain key/value pairs of targetname/failure data for any failures
+    # that occured during the plan. In the case where there are no failures,
+    # the result will be an empty hash.
+    #
+    # Return the results of this final filter/translate operation as the result
+    # of the plan
+    return Hash($final_result.filter |$item| { $item != undef })
   }
 }


### PR DESCRIPTION
This commit updates the gather facts plan and both the sys_output_to_hash and
convert_to_fact_name puppet functions to include error handling. Error
handling logic now stops the plan from failing when individual targets fail
and instead keeps track of what error occurs and outputs it at the end.

As part of this change, the result of the plan is now always a Hash with
key/value data containing target names as keys and error data as values. In
the case that dry_run is true the plan still returns a hash with what data
would have been submitted, but now that hash also includes error data for any
targets that failed.